### PR TITLE
Security enhancment by using Environment Variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Set an environment variable named `REACT_APP_GITHUB_TOKEN=<Your encoded token he
   
 Optionally set the environment variable `REACT_APP_GITHUB_NAME=<YOUR GITHUB USERNAME>` or edit in `src/portfolio.js`
 
-For more information on how to set environment variables click [here](https://www.twilio.com/blog/2017/01/how-to-set-environment-variables.html)
+For more information on how to set environment variables click [here](https://www.twilio.com/blog/2017/01/how-to-set-environment-variables.html) and in react [here](https://create-react-app.dev/docs/adding-custom-environment-variables/)
 
 ```javascript
   const openSource = {

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ git@2.17.1 or higher
 
 ```
 1) BUILD IMAGE : docker build -t developerfolio:latest .
-2) RUN IMAGE: docker run -p 3000:3000 developerfolio:latest
+2) RUN IMAGE: docker run -p 3000:3000 -e REACT_APP_GITHUB_TOKEN=<YOUR TOKEN HERE> developerfolio:latest
 ```
 
 
@@ -77,7 +77,13 @@ Copy the token and open Chrome Developer Console to convert your token to base64
 $ btoa("YOUR GITHUB TOKEN")
 ```
 
-Copy your converted token and paste it in `/src/portfolio.js`
+~~(DEPRECATED) Copy your converted token and paste it in `/src/portfolio.js`~~
+
+Set an environment variable named `REACT_APP_GITHUB_TOKEN=<Your encoded token here>`
+  
+Optionally set the environment variable `REACT_APP_GITHUB_NAME=<YOUR GITHUB USERNAME>` or edit in `src/portfolio.js`
+
+For more information on how to set environment variables click [here](https://www.twilio.com/blog/2017/01/how-to-set-environment-variables.html)
 
 ```javascript
   const openSource = {

--- a/src/portfolio.js
+++ b/src/portfolio.js
@@ -117,8 +117,8 @@ const techStack = {
 To know how to get github key look at readme.md */
 
 const openSource = {
-  githubConvertedToken: "Your Github Converted Token",
-  githubUserName: "Your Github Username"
+  githubConvertedToken: process.env.REACT_APP_GITHUB_TOKEN,
+  githubUserName: process.env.REACT_APP_GITHUB_NAME || "Your github username here"
 };
 
 


### PR DESCRIPTION
This is a proposal to change the token location to the environment variables, in order to enhance security and no leak any private keys in github repositories. Technically this could also make the btoa and atob conversions obsolete (Those are **NOT** security measures to protect private keys), but I didn't change that, because I first wanted to see if you even wanted to implement these changes