### PR TITLE
Update : GraphQl Query from pinnedRepositories to pinnedItems (Important)

### DIFF
--- a/src/components/githubRepoCard/GithubRepoCard.js
+++ b/src/components/githubRepoCard/GithubRepoCard.js
@@ -19,7 +19,7 @@ export default function GithubRepoCard({ repo }) {
               d="M4 9H3V8h1v1zm0-3H3v1h1V6zm0-2H3v1h1V4zm0-2H3v1h1V2zm8-1v12c0 .55-.45 1-1 1H6v2l-1.5-1.5L3 16v-2H1c-.55 0-1-.45-1-1V1c0-.55.45-1 1-1h10c.55 0 1 .45 1 1zm-1 10H1v2h2v-1h3v1h5v-2zm0-10H2v9h9V1z"
             ></path>
           </svg>
-          <p className="repo-name">{repo.node.nameWithOwner}</p>
+          <p className="repo-name">{repo.node.name}</p>
         </div>
         <p className="repo-description">{repo.node.description}</p>
         <div className="repo-stats">

--- a/src/containers/projects/Projects.js
+++ b/src/containers/projects/Projects.js
@@ -29,35 +29,36 @@ export default function Projects() {
     client
       .query({
         query: gql`
-          {
-            repositoryOwner(login: "${openSource.githubUserName}") {
-              ... on User {
-                pinnedRepositories(first: 6) {
-                  edges {
-                    node {
-                      nameWithOwner
-                      description
-                      forkCount
-                      stargazers {
-                        totalCount
-                      }
-                      url
-                      id
-                      diskUsage
-                      primaryLanguage {
-                        name
-                        color
-                      }
-                    }
+        {
+        user(login: "${openSource.githubUserName}") {
+          pinnedItems(first: 6, types: [REPOSITORY]) {
+            totalCount
+            edges {
+              node {
+                ... on Repository {
+                  name
+                  description
+                  forkCount
+                  stargazers {
+                    totalCount
+                  }
+                  url
+                  id
+                  diskUsage
+                  primaryLanguage {
+                    name
+                    color
                   }
                 }
               }
             }
           }
+        }
+      }
         `
       })
       .then(result => {
-        setrepoFunction(result.data.repositoryOwner.pinnedRepositories.edges);
+        setrepoFunction(result.data.user.pinnedItems.edges);
         console.log(result);
       });
   }

--- a/src/portfolio.js
+++ b/src/portfolio.js
@@ -117,8 +117,8 @@ const techStack = {
 To know how to get github key look at readme.md */
 
 const openSource = {
-  githubConvertedToken: "ODM5ODY0MWRmYzUxOTcyZTdhMWMxM2NmZGIwNWU4Yzc3NmI5NTg0ZQ==",
-  githubUserName: "saadpasta"
+  githubConvertedToken: "Your Github Converted Token",
+  githubUserName: "Your Github Username"
 };
 
 

--- a/src/portfolio.js
+++ b/src/portfolio.js
@@ -117,8 +117,8 @@ const techStack = {
 To know how to get github key look at readme.md */
 
 const openSource = {
-  githubConvertedToken: "Your Github Converted Token",
-  githubUserName: "Your Github Username"
+  githubConvertedToken: "ODM5ODY0MWRmYzUxOTcyZTdhMWMxM2NmZGIwNWU4Yzc3NmI5NTg0ZQ==",
+  githubUserName: "saadpasta"
 };
 
 


### PR DESCRIPTION
PinnedRepositories has been deprecated and has been removed from graphql query of Github. So currently we can't get pinned repo's from Github. I came to when I opened `saadpasta.github.io` and can't view my GitHub Projects.

The [changelog](https://developer.github.com/v4/changelog/2019-03-30-schema-changes/) for GitHub GraphQL schema (2019-03-30) mentions that the pinnedRepositories will be deprecated or removed by 2019-07-01. GraphQL API users are requested to use ProfileOwner.pinneditems instead. 


This has been fixed and we can view this API call on `saadpasta.github.io` it has been fixed there. 

#### Query (Can be tested on https://developer.github.com/v4/explorer/ )
`{
  user(login: "saadpasta") {
    pinnedItems(first: 6, types: [REPOSITORY]) {
      totalCount
      edges {
        node {
          ... on Repository {
            name
            description
            forkCount
            stargazers {
              totalCount
            }
            url
            id
            diskUsage
            primaryLanguage {
              name
              color
            }
          }
        }
      }
    }
  }
}
`