### PR TITLE
Layout and CSS fixes

### DIFF
--- a/src/components/button/Button.css
+++ b/src/components/button/Button.css
@@ -26,7 +26,10 @@
   display: flex;
   justify-content: center;
   margin-top: 20px;
-
+}
+.project-button > .main-button{
+  margin-right: 0 !important;
+  margin-top: 0 !important;
 }
 /* Media Query */
 @media (max-width: 768px) {

--- a/src/components/button/Button.css
+++ b/src/components/button/Button.css
@@ -29,7 +29,6 @@
 }
 .project-button > .main-button{
   margin-right: 0 !important;
-  margin-top: 0 !important;
 }
 /* Media Query */
 @media (max-width: 768px) {

--- a/src/components/githubProfileCard/GithubProfileCard.css
+++ b/src/components/githubProfileCard/GithubProfileCard.css
@@ -5,11 +5,12 @@
   width: 100%;
   max-width: 350px;
   height: auto;
+  box-shadow: rgba(0, 0, 0, 1) 0 30px 30px -30px;
+  transition: all 0.3s ease-out;
 }
 
 .profile-image:hover {
-  box-shadow: rgba(0, 0, 0, 1) 0 30px 30px -30px;
-  transition: all 0.3s ease-out;
+  box-shadow: none;
 }
 
 .prof-title {

--- a/src/components/socialMedia/SocialMedia.css
+++ b/src/components/socialMedia/SocialMedia.css
@@ -23,6 +23,7 @@
   user-select: none;
   width: 2.6rem;
   margin-bottom: 10px;
+  transition: 0.2s ease-in;
 }
 
 .facebook i {
@@ -62,7 +63,6 @@
 .facebook i:hover,
 .instagram i:hover {
   background-color: black;
-  transition: 0.3s ease-in;
 }
 
 /* Media Query */


### PR DESCRIPTION
### Changes in this PR
- Reversed github profile image shadow, shadow removes on hover now and matches the other cards aesthetic.
- Fixed `project-button` not being centered on screen.
- 'Hover-out' transitions for social media icons (should've been done in #156)