### PR TITLE
Fix dark mode label

### DIFF
--- a/src/components/ToggleSwitch/ToggleSwitch.css
+++ b/src/components/ToggleSwitch/ToggleSwitch.css
@@ -38,7 +38,7 @@ input:focus + .slider {
 }
 
 input:checked + .slider::before {
-  -webkit-transform: translateX(26px);
+  -webkit-transform: translateX(28px);
   -ms-transform: translateX(26px);
   transform: translateX(26px);
 }


### PR DESCRIPTION
Solved issue #263 "Dark mode slider looking weird".
Dark mode slider was off by 2px when slided to the right.
Please review.