### PR TITLE
Fix dark mode slider checkbox being visible

### DIFF
--- a/src/components/ToggleSwitch/ToggleSwitch.css
+++ b/src/components/ToggleSwitch/ToggleSwitch.css
@@ -5,6 +5,11 @@
   height: 26px;
 }
 
+/* Fix visible slider checkbox */
+input{
+  transform: scale(0.5);
+}
+
 .slider {
   position: absolute;
   cursor: pointer;


### PR DESCRIPTION
I came across the following inconsistency caused by the 'hidden' checkbox behind the slider being visible.

![image](https://user-images.githubusercontent.com/48270786/96472116-b990fa00-124d-11eb-8b10-ef5593779b53.png)
A nit in the design but certainly visible on click.

Wrote a minor quickfix that won't mess up any of our PRs. 