### PR TITLE
Fix talk card box shadow

### DIFF
--- a/src/components/talkCard/TalkCard.css
+++ b/src/components/talkCard/TalkCard.css
@@ -19,7 +19,7 @@
   box-shadow: 0 20px 40px rgba(0, 0, 0, 0.08);
 }
 .dark-rectangle {
-  box-shadow: 4px 1px 20px 0px;
+  box-shadow: 0px 0px 20px 0px;
 }
 .mask {
   clip: rect(0px, 460px, 220px, 0px);


### PR DESCRIPTION
Fixed a minor inconsistency in dark mode shadow for talk card.

Before:

![image](https://user-images.githubusercontent.com/48270786/104086300-ad30a200-527c-11eb-92ea-10566613c35b.png)


After:

![image](https://user-images.githubusercontent.com/48270786/104086295-a30ea380-527c-11eb-8468-0349b87e4bd1.png)
