### PR TITLE
Fixed name height in repo card

### DIFF
--- a/src/components/githubRepoCard/GithubRepoCard.css
+++ b/src/components/githubRepoCard/GithubRepoCard.css
@@ -58,6 +58,7 @@
   letter-spacing: -0.5px;
   overflow: hidden;
   margin: 0px;
+  height: 30px;
 }
 
 .repo-star-svg {


### PR DESCRIPTION
Fixed repo-name height in repo card

![github](https://user-images.githubusercontent.com/52530690/104554276-fc524a80-5661-11eb-8a5a-c960c0828e88.PNG)
