### PR TITLE
Dark Mode Fix

### DIFF
--- a/src/components/githubProfileCard/GithubProfileCard.js
+++ b/src/components/githubProfileCard/GithubProfileCard.js
@@ -25,11 +25,12 @@ export default function GithubProfileCard({prof}) {
               <div className="location-div">
                 <span className="desc-prof">
                   <svg
-                    viewBox="0 0 12 16"
+                    viewBox="-0.5 -2 20 19"
                     version="1.1"
-                    width="20"
-                    height="18"
+                    width="22"
+                    height="16"
                     aria-hidden="true"
+                    stroke="currentColor"
                   >
                     <path
                       fillRule="evenodd"


### PR DESCRIPTION
The Location icon (from github profile) was not changing to a suitable color in the dark mode, so added -> stroke to fix that along with size and placement updates, hope this is useful.