### PR TITLE
Update Font Awesome CDN from version 5.13 to 5.15

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -53,7 +53,7 @@
       gtag('config', 'UA-135618960-2');
     </script>
 
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/FortAwesome/Font-Awesome@5.13.0/css/all.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/FortAwesome/Font-Awesome@5.15.4/css/all.min.css">
 
 
     <!--


### PR DESCRIPTION
# Issue
When using the template, I was unable to display the **rust** language logo.

# Resolution
Font-awesome version in the template is `5.13`. Updating to latest stable `5.15` solved the problem.

PR created to be able to display the icons that came after `5.13`