### PR TITLE
Fixed overflow-x bug when skills section fades in

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -2,6 +2,8 @@
 
 .App {
   text-align: center;
+  width: 100%;
+  overflow-x: hidden;
 }
 
 .App-logo {

--- a/src/containers/skills/Skills.scss
+++ b/src/containers/skills/Skills.scss
@@ -2,6 +2,8 @@
 
 .skills-main-div {
   display: flex;
+  width: 100%;
+  overflow: hidden;
 }
 
 .skills-text-div {


### PR DESCRIPTION
Hey,

This PR fixes #432. Now when the skills section fades in on mobile, there it is not showing the overflow and it stays in its `.skills-main-div` section.