### PR TITLE
Medium cards are not navigating.

### DIFF
--- a/src/containers/blogs/Blogs.js
+++ b/src/containers/blogs/Blogs.js
@@ -83,7 +83,7 @@ export default function Blogs() {
                       key={i}
                       isDark={isDark}
                       blog={{
-                        url: blog.url,
+                        url: blog.link,
                         title: blog.title,
                         description: extractTextContent(blog.content)
                       }}


### PR DESCRIPTION
When a user clicks on the Medium blog card, instead of navigating to the medium page it stays over there only. So instead of mapping blog.link, code is mapped with blog.url. Because of this, no proper URL gets mapped to blog cards.