### PR TITLE
docs: add USE_GITHUB_DATA = "true" to the .env file in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Note: Configuring environment variables before deploying your portfolio is highl
 // .env
 REACT_APP_GITHUB_TOKEN = "YOUR GITHUB TOKEN HERE"
 GITHUB_USERNAME = "YOUR GITHUB USERNAME"
+USE_GITHUB_DATA = "true"
 ```
 
 Set `showGithubProfile` to true or false to show Contact Profile using GitHub, defaults to false.


### PR DESCRIPTION
Currently, github data for one's profile isn't fetched unless we add `USE_GITHUB_DATA = "true"` to the `.env` file. Maybe adding this line in the documentation might be helpful.