### PR TITLE
Equal Opensource Card Sizes

### DIFF
--- a/src/components/githubRepoCard/GithubRepoCard.js
+++ b/src/components/githubRepoCard/GithubRepoCard.js
@@ -13,85 +13,83 @@ export default function GithubRepoCard({repo, isDark}) {
   }
 
   return (
-    <div
-      className={isDark ? "dark-card-mode repo-card-div" : "repo-card-div"}
-    >
-    <Fade bottom duration={1000} distance="20px">
-      <div>
-        <div
-          key={repo.node.id}
-          onClick={() => openUrlInNewTab(repo.node.url, repo.node.name)}
-        >
-          <div className="repo-name-div">
-            <svg
-              aria-hidden="true"
-              className="octicon repo-svg"
-              height="20"
-              role="img"
-              viewBox="0 0 12 16"
-              width="14"
-            >
-              <path
-                fill-rule="evenodd"
-                d="M4 9H3V8h1v1zm0-3H3v1h1V6zm0-2H3v1h1V4zm0-2H3v1h1V2zm8-1v12c0 .55-.45 1-1 1H6v2l-1.5-1.5L3 16v-2H1c-.55 0-1-.45-1-1V1c0-.55.45-1 1-1h10c.55 0 1 .45 1 1zm-1 10H1v2h2v-1h3v1h5v-2zm0-10H2v9h9V1z"
-              ></path>
-            </svg>
-            <p className="repo-name">{repo.node.name}</p>
-          </div>
-          <p className="repo-description">{repo.node.description}</p>
-          <div className="repo-stats">
-            <div className="repo-left-stat">
-              {repo.node.primaryLanguage !== null && (
-                <span>
-                  <div
-                    className="language-color"
-                    style={{backgroundColor: repo.node.primaryLanguage.color}}
-                  ></div>
-                  <p>{repo.node.primaryLanguage.name}</p>
-                </span>
-              )}
-              <span>
-                <svg
-                  aria-hidden="true"
-                  className="octicon repo-star-svg"
-                  height="20"
-                  role="img"
-                  viewBox="0 0 10 16"
-                  width="12"
-                  fill="rgb(106, 115, 125)"
-                >
-                  <path
-                    fill-rule="evenodd"
-                    d="M8 1a1.993 1.993 0 0 0-1 3.72V6L5 8 3 6V4.72A1.993 1.993 0 0 0 2 1a1.993 1.993 0 0 0-1 3.72V6.5l3 3v1.78A1.993 1.993 0 0 0 5 15a1.993 1.993 0 0 0 1-3.72V9.5l3-3V4.72A1.993 1.993 0 0 0 8 1zM2 4.2C1.34 4.2.8 3.65.8 3c0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zm3 10c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zm3-10c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2z"
-                  ></path>
-                </svg>
-                <p>{repo.node.forkCount}</p>
-              </span>
-              <span>
-                <svg
-                  aria-hidden="true"
-                  className="octicon repo-star-svg"
-                  height="20"
-                  role="img"
-                  viewBox="0 0 14 16"
-                  width="14"
-                  fill="rgb(106, 115, 125)"
-                >
-                  <path
-                    fill-rule="evenodd"
-                    d="M14 6l-4.9-.64L7 1 4.9 5.36 0 6l3.6 3.26L2.67 14 7 11.67 11.33 14l-.93-4.74L14 6z"
-                  ></path>
-                </svg>
-                <p>{repo.node.stargazers.totalCount}</p>
-              </span>
+    <div className={isDark ? "dark-card-mode repo-card-div" : "repo-card-div"}>
+      <Fade bottom duration={1000} distance="20px">
+        <div>
+          <div
+            key={repo.node.id}
+            onClick={() => openUrlInNewTab(repo.node.url, repo.node.name)}
+          >
+            <div className="repo-name-div">
+              <svg
+                aria-hidden="true"
+                className="octicon repo-svg"
+                height="20"
+                role="img"
+                viewBox="0 0 12 16"
+                width="14"
+              >
+                <path
+                  fill-rule="evenodd"
+                  d="M4 9H3V8h1v1zm0-3H3v1h1V6zm0-2H3v1h1V4zm0-2H3v1h1V2zm8-1v12c0 .55-.45 1-1 1H6v2l-1.5-1.5L3 16v-2H1c-.55 0-1-.45-1-1V1c0-.55.45-1 1-1h10c.55 0 1 .45 1 1zm-1 10H1v2h2v-1h3v1h5v-2zm0-10H2v9h9V1z"
+                ></path>
+              </svg>
+              <p className="repo-name">{repo.node.name}</p>
             </div>
-            <div className="repo-right-stat">
-              <p>{repo.node.diskUsage} KB</p>
+            <p className="repo-description">{repo.node.description}</p>
+            <div className="repo-stats">
+              <div className="repo-left-stat">
+                {repo.node.primaryLanguage !== null && (
+                  <span>
+                    <div
+                      className="language-color"
+                      style={{backgroundColor: repo.node.primaryLanguage.color}}
+                    ></div>
+                    <p>{repo.node.primaryLanguage.name}</p>
+                  </span>
+                )}
+                <span>
+                  <svg
+                    aria-hidden="true"
+                    className="octicon repo-star-svg"
+                    height="20"
+                    role="img"
+                    viewBox="0 0 10 16"
+                    width="12"
+                    fill="rgb(106, 115, 125)"
+                  >
+                    <path
+                      fill-rule="evenodd"
+                      d="M8 1a1.993 1.993 0 0 0-1 3.72V6L5 8 3 6V4.72A1.993 1.993 0 0 0 2 1a1.993 1.993 0 0 0-1 3.72V6.5l3 3v1.78A1.993 1.993 0 0 0 5 15a1.993 1.993 0 0 0 1-3.72V9.5l3-3V4.72A1.993 1.993 0 0 0 8 1zM2 4.2C1.34 4.2.8 3.65.8 3c0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zm3 10c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zm3-10c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2z"
+                    ></path>
+                  </svg>
+                  <p>{repo.node.forkCount}</p>
+                </span>
+                <span>
+                  <svg
+                    aria-hidden="true"
+                    className="octicon repo-star-svg"
+                    height="20"
+                    role="img"
+                    viewBox="0 0 14 16"
+                    width="14"
+                    fill="rgb(106, 115, 125)"
+                  >
+                    <path
+                      fill-rule="evenodd"
+                      d="M14 6l-4.9-.64L7 1 4.9 5.36 0 6l3.6 3.26L2.67 14 7 11.67 11.33 14l-.93-4.74L14 6z"
+                    ></path>
+                  </svg>
+                  <p>{repo.node.stargazers.totalCount}</p>
+                </span>
+              </div>
+              <div className="repo-right-stat">
+                <p>{repo.node.diskUsage} KB</p>
+              </div>
             </div>
           </div>
         </div>
-      </div>
-    </Fade>
+      </Fade>
     </div>
   );
 }

--- a/src/components/githubRepoCard/GithubRepoCard.js
+++ b/src/components/githubRepoCard/GithubRepoCard.js
@@ -80,7 +80,7 @@ export default function GithubRepoCard({repo, isDark}) {
                       d="M14 6l-4.9-.64L7 1 4.9 5.36 0 6l3.6 3.26L2.67 14 7 11.67 11.33 14l-.93-4.74L14 6z"
                     ></path>
                   </svg>
-                  <p>{repo.node.stargazers.totalCount}</p>
+                  <p>{repo.node.stargazers.totalCount.toLocaleString("en-US")}</p>
                 </span>
               </div>
               <div className="repo-right-stat">

--- a/src/components/githubRepoCard/GithubRepoCard.js
+++ b/src/components/githubRepoCard/GithubRepoCard.js
@@ -13,10 +13,12 @@ export default function GithubRepoCard({repo, isDark}) {
   }
 
   return (
+    <div
+      className={isDark ? "dark-card-mode repo-card-div" : "repo-card-div"}
+    >
     <Fade bottom duration={1000} distance="20px">
       <div>
         <div
-          className={isDark ? "dark-card-mode repo-card-div" : "repo-card-div"}
           key={repo.node.id}
           onClick={() => openUrlInNewTab(repo.node.url, repo.node.name)}
         >
@@ -90,5 +92,6 @@ export default function GithubRepoCard({repo, isDark}) {
         </div>
       </div>
     </Fade>
+    </div>
   );
 }

--- a/src/components/githubRepoCard/GithubRepoCard.scss
+++ b/src/components/githubRepoCard/GithubRepoCard.scss
@@ -9,7 +9,21 @@
   -webkit-transition: all 0.3s ease;
   -o-transition: all 0.3s ease;
   transition: all 0.3s ease;
+  flex: 1 1 25%;
 }
+
+@media (max-width: 1200px) {
+  .repo-card-div {
+    flex: 1 1 40%;
+  }
+}
+
+@media (max-width: 768px) {
+  .repo-card-div {
+    flex: 1 1 100%;
+  }
+}
+
 .repo-card-div:hover {
   box-shadow: $lightBoxShadowDark 0px 20px 30px -10px;
 }
@@ -54,8 +68,6 @@
 }
 
 .repo-name {
-  white-space: nowrap;
-  text-overflow: ellipsis;
   color: $githubRepoCardRepoNameColor;
   margin-bottom: 0.75rem;
   font-size: 25px;

--- a/src/containers/projects/Project.scss
+++ b/src/containers/projects/Project.scss
@@ -10,8 +10,9 @@
 }
 
 .repo-cards-div-main {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
   gap: 1rem 1rem;
 }
 


### PR DESCRIPTION
Makes all the opensource project card sizes equal.

### Changes
1. Changed the open-source project cards from the grid layout to flex.
2. Made the heights to be equal.
3. Also we will cut the name of the project if it is too long.

Addresses Issue #490 

@kartikcho Do have a look!

**Note:** Seems like the vercel auto deployment is not configured to show up the opensource cards, so you will have to test it locally i guess.