### PR TITLE
Github RepoCard Icon Color

### DIFF
--- a/src/components/githubRepoCard/GithubRepoCard.scss
+++ b/src/components/githubRepoCard/GithubRepoCard.scss
@@ -84,6 +84,11 @@
 .dark-card-mode p {
   color: $textColorDark;
 }
+
+.dark-card-mode .repo-svg {
+  fill: $textColorDark;
+}
+
 .dark-card-mode:hover {
   background-color: $buttonColor !important;
   box-shadow: 0px 0px 16px $darkBoxShadow;


### PR DESCRIPTION
Fixed the colour of the icon in the GitHub repo card.

Currently, the colour of the GitHub repo card icon doesn't change when we change to dark mode. 

After this fix, the icons' colour will change to white just like the text on the card.

![image](https://user-images.githubusercontent.com/40917760/187084409-5593773d-be30-466f-a7b1-00896f0cc7f1.png)
