### PR TITLE
Feature/GitHub jobs

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -28,7 +28,6 @@ if (USE_GITHUB_DATA === "true") {
   user(login:"${GITHUB_USERNAME}") { 
     name
     bio
-    isHireable
     avatarUrl
     location
     pinnedItems(first: 6, types: [REPOSITORY]) {

--- a/src/components/githubProfileCard/GithubProfileCard.js
+++ b/src/components/githubProfileCard/GithubProfileCard.js
@@ -1,12 +1,12 @@
 import React from "react";
 import "./GithubProfileCard.scss";
 import SocialMedia from "../../components/socialMedia/SocialMedia";
-import {contactInfo} from "../../portfolio";
+import {contactInfo, isHireable} from "../../portfolio";
 import emoji from "react-easy-emoji";
 import {Fade} from "react-reveal";
 
 export default function GithubProfileCard({prof}) {
-  if (prof.isHireable) {
+  if (isHireable) {
     prof.hireable = "Yes";
   } else {
     prof.hireable = "No";

--- a/src/portfolio.js
+++ b/src/portfolio.js
@@ -374,6 +374,8 @@ const twitterDetails = {
   display: true // Set true to display this section, defaults to false
 };
 
+const isHireable = true // Set false if you are not looking for a job
+
 export {
   illustration,
   greeting,
@@ -390,5 +392,6 @@ export {
   talkSection,
   podcastSection,
   contactInfo,
-  twitterDetails
+  twitterDetails,
+  isHireable
 };

--- a/src/portfolio.js
+++ b/src/portfolio.js
@@ -374,7 +374,7 @@ const twitterDetails = {
   display: true // Set true to display this section, defaults to false
 };
 
-const isHireable = true // Set false if you are not looking for a job
+const isHireable = true; // Set false if you are not looking for a job
 
 export {
   illustration,

--- a/src/portfolio.js
+++ b/src/portfolio.js
@@ -374,7 +374,7 @@ const twitterDetails = {
   display: true // Set true to display this section, defaults to false
 };
 
-const isHireable = true; // Set false if you are not looking for a job
+const isHireable = false; // Set false if you are not looking for a job. Also isHireable will be display as Open for opportunities: Yes/No in the GitHub footer
 
 export {
   illustration,


### PR DESCRIPTION
## Feature description
This feature is related with this [issue](https://github.com/saadpasta/developerFolio/issues/507).  So, considering that `isHireable` is [deprecated](https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-personal-account-settings/what-does-the-available-for-hire-checkbox-do). 

Now, you can set if you are looking for a new job in `portfolio.js`, instead of the API get the info.