### PR TITLE
Check for School Logo and Render

### DIFF
--- a/src/components/educationCard/EducationCard.js
+++ b/src/components/educationCard/EducationCard.js
@@ -23,15 +23,17 @@ export default function EducationCard({school}) {
     <div>
       <Fade left duration={1000}>
         <div className="education-card">
-          <div className="education-card-left">
-            <img
-              crossOrigin={"anonymous"}
-              ref={imgRef}
-              className="education-roundedimg"
-              src={school.logo}
-              alt={school.schoolName}
-            />
-          </div>
+          {school.logo && (
+            <div className="education-card-left">
+              <img
+                crossOrigin={"anonymous"}
+                ref={imgRef}
+                className="education-roundedimg"
+                src={school.logo}
+                alt={school.schoolName}
+              />
+            </div>
+          )}
           <div className="education-card-right">
             <h5 className="education-text-school">{school.schoolName}</h5>
 


### PR DESCRIPTION
Just added a simple check for school logo.

### Reason
Without the check if the user doesn't give a logo, then it would render something weird which is not good. As discussed in #521 

### Before
![image](https://user-images.githubusercontent.com/40917760/188932952-390a3937-0312-42fc-9899-255d0500449d.png)

### Now
![image](https://user-images.githubusercontent.com/40917760/188942339-e2868918-d732-4d95-b459-8a56426df5db.png)
