### PR TITLE
feat: add icon for dark and light theme

### DIFF
--- a/src/components/ToggleSwitch/ToggleSwitch.js
+++ b/src/components/ToggleSwitch/ToggleSwitch.js
@@ -8,15 +8,6 @@ const ToggleSwitch = () => {
   const [isChecked, setChecked] = useState(isDark);
   const styleContext = useContext(StyleContext);
 
-  const emojis = {
-    light: emoji("☀️"),
-    dark: emoji("🌜")
-  };
-  const themeStyle = {
-    "--light-mode": emojis.light,
-    "--dark-mode": emojis.dark
-  };
-
   return (
     <label className="switch">
       <input
@@ -29,7 +20,7 @@ const ToggleSwitch = () => {
       />
       <span className="slider round">
         <span className="emoji">
-          {isChecked ? themeStyle["--dark-mode"] : themeStyle["--light-mode"]}
+          {isChecked ? emoji("🌜") : emoji("☀️")}
         </span>
       </span>
     </label>

--- a/src/components/ToggleSwitch/ToggleSwitch.js
+++ b/src/components/ToggleSwitch/ToggleSwitch.js
@@ -1,4 +1,5 @@
 import React, {useState, useContext} from "react";
+import emoji from 'react-easy-emoji'
 import StyleContext from "../../contexts/StyleContext";
 import "./ToggleSwitch.scss";
 
@@ -7,6 +8,16 @@ const ToggleSwitch = () => {
   const [isChecked, setChecked] = useState(isDark);
   const styleContext = useContext(StyleContext);
 
+  const emojis = {
+    light: emoji('☀️'), 
+    dark: emoji('🌜')
+  }
+  const themeStyle = {
+    "--light-mode": emojis.light,
+    "--dark-mode": emojis.dark
+  }
+
+  console.log(isChecked)
   return (
     <label className="switch">
       <input
@@ -17,7 +28,9 @@ const ToggleSwitch = () => {
           setChecked(!isChecked);
         }}
       />
-      <span className="slider round"></span>
+      <span className="slider round">
+        <span className="emoji">{isChecked ? themeStyle["--dark-mode"] : themeStyle["--light-mode"]}</span>
+      </span>
     </label>
   );
 };

--- a/src/components/ToggleSwitch/ToggleSwitch.js
+++ b/src/components/ToggleSwitch/ToggleSwitch.js
@@ -1,5 +1,5 @@
 import React, {useState, useContext} from "react";
-import emoji from 'react-easy-emoji'
+import emoji from "react-easy-emoji";
 import StyleContext from "../../contexts/StyleContext";
 import "./ToggleSwitch.scss";
 
@@ -9,15 +9,15 @@ const ToggleSwitch = () => {
   const styleContext = useContext(StyleContext);
 
   const emojis = {
-    light: emoji('☀️'), 
-    dark: emoji('🌜')
-  }
+    light: emoji("☀️"),
+    dark: emoji("🌜")
+  };
   const themeStyle = {
     "--light-mode": emojis.light,
     "--dark-mode": emojis.dark
-  }
+  };
 
-  console.log(isChecked)
+  console.log(isChecked);
   return (
     <label className="switch">
       <input
@@ -29,7 +29,9 @@ const ToggleSwitch = () => {
         }}
       />
       <span className="slider round">
-        <span className="emoji">{isChecked ? themeStyle["--dark-mode"] : themeStyle["--light-mode"]}</span>
+        <span className="emoji">
+          {isChecked ? themeStyle["--dark-mode"] : themeStyle["--light-mode"]}
+        </span>
       </span>
     </label>
   );

--- a/src/components/ToggleSwitch/ToggleSwitch.js
+++ b/src/components/ToggleSwitch/ToggleSwitch.js
@@ -17,7 +17,6 @@ const ToggleSwitch = () => {
     "--dark-mode": emojis.dark
   };
 
-  console.log(isChecked);
   return (
     <label className="switch">
       <input

--- a/src/components/ToggleSwitch/ToggleSwitch.js
+++ b/src/components/ToggleSwitch/ToggleSwitch.js
@@ -19,9 +19,7 @@ const ToggleSwitch = () => {
         }}
       />
       <span className="slider round">
-        <span className="emoji">
-          {isChecked ? emoji("🌜") : emoji("☀️")}
-        </span>
+        <span className="emoji">{isChecked ? emoji("🌜") : emoji("☀️")}</span>
       </span>
     </label>
   );

--- a/src/components/ToggleSwitch/ToggleSwitch.scss
+++ b/src/components/ToggleSwitch/ToggleSwitch.scss
@@ -57,6 +57,13 @@ input:checked + .slider::before {
 
 .slider.round::before {
   border-radius: 50%;
+  content: '☀️';
+  display: grid;
+  place-items: center;
+}
+
+input:checked + .slider::before {
+  content: '🌜'
 }
 
 .slider::after {

--- a/src/components/ToggleSwitch/ToggleSwitch.scss
+++ b/src/components/ToggleSwitch/ToggleSwitch.scss
@@ -44,7 +44,8 @@ input:focus + .slider {
   box-shadow: $toggleCheck;
 }
 
-input:checked + .slider::before {
+input:checked + .slider::before,
+input:checked + .slider > .emoji { 
   -webkit-transform: translateX(26px);
   -ms-transform: translateX(26px);
   transform: translateX(26px);
@@ -53,17 +54,14 @@ input:checked + .slider::before {
 /* Rounded sliders */
 .slider.round {
   border-radius: 34px;
+  display: flex;
+  align-items: center;
 }
 
 .slider.round::before {
   border-radius: 50%;
-  content: "☀️";
   display: grid;
   place-items: center;
-}
-
-input:checked + .slider::before {
-  content: "🌜";
 }
 
 .slider::after {
@@ -78,6 +76,13 @@ input:checked + .slider::after {
   position: absolute;
   right: 56.3%;
   bottom: 14.5%;
+}
+
+.emoji {
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  margin-left: 2px;
 }
 
 @media all and (max-width: 786px) and (min-width: 425px) {

--- a/src/components/ToggleSwitch/ToggleSwitch.scss
+++ b/src/components/ToggleSwitch/ToggleSwitch.scss
@@ -45,7 +45,7 @@ input:focus + .slider {
 }
 
 input:checked + .slider::before,
-input:checked + .slider > .emoji { 
+input:checked + .slider > .emoji {
   -webkit-transform: translateX(26px);
   -ms-transform: translateX(26px);
   transform: translateX(26px);

--- a/src/components/ToggleSwitch/ToggleSwitch.scss
+++ b/src/components/ToggleSwitch/ToggleSwitch.scss
@@ -57,13 +57,13 @@ input:checked + .slider::before {
 
 .slider.round::before {
   border-radius: 50%;
-  content: '☀️';
+  content: "☀️";
   display: grid;
   place-items: center;
 }
 
 input:checked + .slider::before {
-  content: '🌜'
+  content: "🌜";
 }
 
 .slider::after {


### PR DESCRIPTION
## closes #528 

## Changes proposed
- Add icons ☀️, 🌜 for light and dark mode respectively

## Screenshot
![image](https://user-images.githubusercontent.com/78784850/193405901-a07fbdb9-bcfd-425b-aa1e-0478b1e517e9.png)
