### PR TITLE
center image vertically

### DIFF
--- a/src/components/achievementCard/AchievementCard.scss
+++ b/src/components/achievementCard/AchievementCard.scss
@@ -40,7 +40,9 @@
   position: relative;
   height: 250px;
   overflow: hidden;
-  text-align: center;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 .achievement-cards-div {
   display: grid;

--- a/src/containers/StartupProjects/StartupProjects.scss
+++ b/src/containers/StartupProjects/StartupProjects.scss
@@ -53,7 +53,9 @@
   position: relative;
   height: 250px;
   overflow: hidden;
-  text-align: center;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
 .projects-container {


### PR DESCRIPTION
# Description

Centering image vertically in achievement card and big project section. If an image used in achievement card or big project is landscape (width is more than height) the image doesn't aligns vertically centered. By using flex we can center images vertically and horizontally.

Before:
![Screenshot 2022-10-03 214120](https://user-images.githubusercontent.com/55500003/193628268-d8ca277b-a42c-4568-9b19-57590e1f4f42.png)
![Screenshot 2022-10-03 214209](https://user-images.githubusercontent.com/55500003/193628288-1409de6e-b6a3-47e0-8372-331598637e93.png)


After:
![after1](https://user-images.githubusercontent.com/55500003/193628534-3ada62c5-d8a4-4cb8-ab5d-fb0ecc429721.png)
![after2](https://user-images.githubusercontent.com/55500003/193628318-40c0ee29-52fe-4ff5-844e-2f264096f9e1.png)


## Type of change

<!-- Please delete options that are not relevant.-->


- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
