### PR TITLE
Update README.md on generating github token

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ npm start
 
 ## Linking Portfolio to GitHub
 
-Generate a GitHub personal access token following these [instructions](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line) (make sure you don't select any scope just generate a simple token). If you are using [GitHub Actions](#configuring-github-actions-recommended) to deploy your portfolio you can skip this section.
+Generate a classic GitHub personal access token following these [instructions](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token#creating-a-personal-access-token-classic) (make sure you don't select any scope just generate a simple token). If you are using [GitHub Actions](#configuring-github-actions-recommended) to deploy your portfolio you can skip this section.
 
 1. Create a file called .env in the root directory of your project (if not done already in section: [How To Use](#how-to-use))
 


### PR DESCRIPTION
# Description

GitHub seems to have launched a beta version of fine-grained tokens, but this project requires the classic tokens to setup. This PR updates the README to make it clearer for the users to choose the classic token instead of the beta fine-grained tokens.

![github_token](https://user-images.githubusercontent.com/34273644/197332522-f2ad057d-3998-4b1d-8d64-07eab73f35ab.png)

## Type of change

<!-- Please delete options that are not relevant.-->


- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
