### PR TITLE
react-easy-emoji version update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "jest-canvas-mock": "^2.3.1",
         "react": "^16.10.2",
         "react-dom": "^16.10.2",
-        "react-easy-emoji": "^1.3.0",
+        "react-easy-emoji": "^1.8.1",
         "react-headroom": "^3.0.0",
         "react-lottie": "^1.2.3",
         "react-reveal": "^1.2.2",
@@ -10742,20 +10742,10 @@
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
     },
-    "node_modules/lodash.assign": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
-    },
     "node_modules/lodash.escape": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-4.0.1.tgz",
       "integrity": "sha1-yQRGkMIeBClL6qUXcS/e0fqI3pg="
-    },
-    "node_modules/lodash.flatten": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
     },
     "node_modules/lodash.flattendeep": {
       "version": "4.4.0",
@@ -10766,11 +10756,6 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
       "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
-    },
-    "node_modules/lodash.isstring": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
     },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
@@ -14333,15 +14318,20 @@
       }
     },
     "node_modules/react-easy-emoji": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/react-easy-emoji/-/react-easy-emoji-1.4.0.tgz",
-      "integrity": "sha512-TcufijpuWKgYgzbySEBukNef+y0HI/4PAJ4gc9vb1CF7Q4CcAS2ZV8VMZk0ObtKKwJJfVgAHVt86nXWOed8QXg==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/react-easy-emoji/-/react-easy-emoji-1.8.1.tgz",
+      "integrity": "sha512-wAf2x+cjwtOlLfXnjc0J3k5B2PDZdoxd1BjtfKr5tq2AL7t2ygvByJQWgFOyN28xg3qe8EKBM6pKxGP+qrGWuQ==",
       "dependencies": {
-        "lodash.assign": "^4.0.8",
-        "string-replace-to-array": "^1.0.1"
+        "string-replace-to-array": "^2.1.0"
       },
       "peerDependencies": {
-        "react": "^0.14.0 || ^15.0.0 || ^16.0.0"
+        "@types/react": ">=0.14.0",
+        "react": ">=0.14.27"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-error-overlay": {
@@ -16262,14 +16252,9 @@
       }
     },
     "node_modules/string-replace-to-array": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string-replace-to-array/-/string-replace-to-array-1.0.3.tgz",
-      "integrity": "sha1-yT66mZpe4k1zGuu69auja18Y978=",
-      "dependencies": {
-        "invariant": "^2.2.1",
-        "lodash.flatten": "^4.2.0",
-        "lodash.isstring": "^4.0.1"
-      }
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/string-replace-to-array/-/string-replace-to-array-2.1.0.tgz",
+      "integrity": "sha512-xG2w4fE5FsTXS4AFxoF3uctByqTIFBX8lFRNcPcIznTVCMXbYvbatkPVLpAo13tfuWtzbWEV6u5bjoE9bOv87w=="
     },
     "node_modules/string-width": {
       "version": "4.2.0",
@@ -27267,20 +27252,10 @@
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
     },
-    "lodash.assign": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
-    },
     "lodash.escape": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-4.0.1.tgz",
       "integrity": "sha1-yQRGkMIeBClL6qUXcS/e0fqI3pg="
-    },
-    "lodash.flatten": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
     },
     "lodash.flattendeep": {
       "version": "4.4.0",
@@ -27291,11 +27266,6 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
       "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
-    },
-    "lodash.isstring": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
     },
     "lodash.memoize": {
       "version": "4.1.2",
@@ -30206,12 +30176,11 @@
       }
     },
     "react-easy-emoji": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/react-easy-emoji/-/react-easy-emoji-1.4.0.tgz",
-      "integrity": "sha512-TcufijpuWKgYgzbySEBukNef+y0HI/4PAJ4gc9vb1CF7Q4CcAS2ZV8VMZk0ObtKKwJJfVgAHVt86nXWOed8QXg==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/react-easy-emoji/-/react-easy-emoji-1.8.1.tgz",
+      "integrity": "sha512-wAf2x+cjwtOlLfXnjc0J3k5B2PDZdoxd1BjtfKr5tq2AL7t2ygvByJQWgFOyN28xg3qe8EKBM6pKxGP+qrGWuQ==",
       "requires": {
-        "lodash.assign": "^4.0.8",
-        "string-replace-to-array": "^1.0.1"
+        "string-replace-to-array": "^2.1.0"
       }
     },
     "react-error-overlay": {
@@ -31748,14 +31717,9 @@
       }
     },
     "string-replace-to-array": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string-replace-to-array/-/string-replace-to-array-1.0.3.tgz",
-      "integrity": "sha1-yT66mZpe4k1zGuu69auja18Y978=",
-      "requires": {
-        "invariant": "^2.2.1",
-        "lodash.flatten": "^4.2.0",
-        "lodash.isstring": "^4.0.1"
-      }
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/string-replace-to-array/-/string-replace-to-array-2.1.0.tgz",
+      "integrity": "sha512-xG2w4fE5FsTXS4AFxoF3uctByqTIFBX8lFRNcPcIznTVCMXbYvbatkPVLpAo13tfuWtzbWEV6u5bjoE9bOv87w=="
     },
     "string-width": {
       "version": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "jest-canvas-mock": "^2.3.1",
     "react": "^16.10.2",
     "react-dom": "^16.10.2",
-    "react-easy-emoji": "^1.3.0",
+    "react-easy-emoji": "^1.8.1",
     "react-headroom": "^3.0.0",
     "react-lottie": "^1.2.3",
     "react-reveal": "^1.2.2",


### PR DESCRIPTION
# Description

Due to [maxcdn shutdown](https://github.com/appfigures/react-easy-emoji/issues/23), the react-easy-emoji old version doesn't show emoji on portfolio, simple fix to that was to update it's version

Fixes #570 

## Type of change

<!-- Please delete options that are not relevant.-->


- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
