### PR TITLE
Add missing hover css to projects card footer

### DIFF
--- a/src/containers/StartupProjects/StartupProjects.scss
+++ b/src/containers/StartupProjects/StartupProjects.scss
@@ -82,6 +82,10 @@
   transition: 0.2s ease-in;
 }
 
+.project-card-footer span.project-tag:hover {
+  background: $buttonHover;
+}
+
 @media (max-width: 768px) {
   .project-subtitle {
     font-size: 16px;


### PR DESCRIPTION
# Description

The projects card footer links have the same styling as the achievement card footer links, but do not have the same hover over styling applied. Applying the hover over should make the buttons more consistent.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
