### PR TITLE
fix nginx conf and dockerization

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,17 @@
+server {
+    listen       80;
+    server_name  localhost;
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+	    try_files $uri /index.html;
+    }
+
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+
+
+}


### PR DESCRIPTION
# Description

Fixed Dockerization of the react app, previously, if you click on any link (or use react-router), docker will give you 404, because it only know the hard-coded location of the HTML file. Right now I am serving the dockerize app through nginx and set the conf for nginx to first try other routes from react app and if not found then gives 404.

Fixes #629

## Type of change

<!-- Please delete options that are not relevant.-->


- [ ] Bug fix (non-breaking change which fixes an issue)
