### PR TITLE
Fix: Removed Hover Effect from Theme Toggle Button (#552)

### DIFF
--- a/src/components/header/Header.scss
+++ b/src/components/header/Header.scss
@@ -16,7 +16,7 @@
   color: $textColorDark !important;
 }
 
-.dark-menu li a:hover {
+.dark-menu li:not(:last-child) a:hover {
   background-color: $buttonColor !important;
 }
 
@@ -45,7 +45,7 @@
   text-decoration: none;
 }
 
-.header li a:hover,
+.header li:not(:last-child) a:hover,
 .header .menu-btn:hover {
   background-color: $headerHoverBG;
 }


### PR DESCRIPTION
This commit aims to improve the user experience by removing the hover effect from the theme toggle button as mentioned in the [ issue #552 ]
