### PR TITLE
fix(ci): update workflow to use node 18.x

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node.js 🔧
         uses: actions/setup-node@v3.8.1
         with:
-          node-version: 16.x
+          node-version: 18.x
 
       - name: Update npm 🚀
         run: npm install -g npm@latest

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: actions/setup-node@v3.8.1
         with:
-          node-version: 16.x
+          node-version: 18.x
       
       - name: Install 🔧 # Install dependencies
         run: |


### PR DESCRIPTION
Bumped up the node-version to 18.x for github workflows
