### PR TITLE
Fix: Conditionally Render Company Logo in Experience Card

### DIFF
--- a/src/components/experienceCard/ExperienceCard.js
+++ b/src/components/experienceCard/ExperienceCard.js
@@ -38,14 +38,14 @@ export default function ExperienceCard({cardInfo, isDark}) {
           <h5 className="experience-text-company">{cardInfo.company}</h5>
         </div>
 
-        <img
+        {cardInfo.companylogo && (<img
           crossOrigin={"anonymous"}
           ref={imgRef}
           className="experience-roundedimg"
           src={cardInfo.companylogo}
           alt={cardInfo.company}
           onLoad={() => getColorArrays()}
-        />
+        />)}
       </div>
       <div className="experience-text-details">
         <h5


### PR DESCRIPTION
**Changes Made:**
Added a condition to check if cardInfo.companylogo exists before rendering the <img> tag in the experience card component.

**Reason for Change:**
Ensures that a circular logo icon is displayed only when a company logo is provided. This prevents the display of an empty circular icon when cardInfo.companylogo is not defined, improving the user experience.

**Testing Done:**
Tested the change locally with scenarios where cardInfo.companylogo is both defined and undefined.
Verified that the experience card renders correctly in both cases without errors.

**Additional Notes:**
This change enhances the component's robustness by handling cases where the company logo is not available gracefully.
