### PR TITLE
Fix: fetch public files (profile.json, blog.json) from public url

### DIFF
--- a/src/containers/blogs/Blogs.js
+++ b/src/containers/blogs/Blogs.js
@@ -23,7 +23,7 @@ export default function Blogs() {
   useEffect(() => {
     if (blogSection.displayMediumBlogs === "true") {
       const getProfileData = () => {
-        fetch("/blogs.json")
+        fetch(`${process.env.PUBLIC_URL}/blogs.json`)
           .then(result => {
             if (result.ok) {
               return result.json();

--- a/src/containers/profile/Profile.js
+++ b/src/containers/profile/Profile.js
@@ -16,7 +16,7 @@ export default function Profile() {
   useEffect(() => {
     if (openSource.showGithubProfile === "true") {
       const getProfileData = () => {
-        fetch("/profile.json")
+        fetch(`${process.env.PUBLIC_URL}/profile.json`)
           .then(result => {
             if (result.ok) {
               return result.json();

--- a/src/containers/projects/Projects.js
+++ b/src/containers/projects/Projects.js
@@ -16,7 +16,7 @@ export default function Projects() {
 
   useEffect(() => {
     const getRepoData = () => {
-      fetch("/profile.json")
+      fetch(`${process.env.PUBLIC_URL}/profile.json`)
         .then(result => {
           if (result.ok) {
             return result.json();


### PR DESCRIPTION
# Description

This PR implements a fix for fetching public files (`profile.json`, `blogs.json`) from the site's public URL instead of the root (`/`) path. This change addresses an issue where the files were not found when deployed at a different path, ensuring that GitHub profiles and Medium blogs are displayed as intended.

Fixes #655
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
