### PR TITLE
fix: greeting resume link should be used when clicking on download my…

### DIFF
--- a/src/containers/greeting/Greeting.js
+++ b/src/containers/greeting/Greeting.js
@@ -41,7 +41,9 @@ export default function Greeting() {
                 <Button text="Contact me" href="#contact" />
                 {greeting.resumeLink && (
                   <a
-                    href={require("./resume.pdf")}
+                    href={greeting.resumeLink}
+                    target="_blank"
+                    rel="noopener noreferrer"
                     download="Resume.pdf"
                     className="download-link-button"
                   >


### PR DESCRIPTION
# Description

The resume greeting link is just being used to show the Download My Resume button. It should be used on the anchor tag present in the button so that the resume link can be opened in a new tab.


