### PR TITLE
feat: remove background color on hover of theme toggle button

### DIFF
--- a/src/components/header/Header.scss
+++ b/src/components/header/Header.scss
@@ -20,6 +20,10 @@
   background-color: $buttonColor !important;
 }
 
+.dark-menu li:last-child a:hover {
+  background-color: transparent !important;
+}
+
 .header {
   background-color: $lightBackground1;
   max-width: 100%;
@@ -48,6 +52,9 @@
 .header li a:hover,
 .header .menu-btn:hover {
   background-color: $headerHoverBG;
+}
+.header li:last-child a:hover{
+  background-color: transparent;
 }
 
 .header .logo {


### PR DESCRIPTION
# Description

Since, theme toggle button is an independent functionality and not a link , when a user hovers on the theme toggle button, there is no need to show background color like it is being show for other header links.


## Type of change

- [ ] New feature (non-breaking change which adds functionality)