### PR TITLE
fix: download resume and contact buttons were distorting the ui in sm…

### DIFF
--- a/src/containers/greeting/Greeting.scss
+++ b/src/containers/greeting/Greeting.scss
@@ -115,6 +115,14 @@
   }
 }
 
+@media (max-width: 480px) {
+  .button-greeting-div {
+    flex-direction: column;
+    align-items: center;
+    flex-direction: column-reverse;
+  }
+}
+
 @media (max-width: 320px) {
   .main {
     width: auto;


### PR DESCRIPTION
# Description

The buttons : CONTACT ME and DOWNLOAD MY RESUME buttons were distorting the ui in small screens (at around 410px).
So now they will be visible in a column rather than in a row and will be centrally aligned. This fix is done for all the screen sizes <= 480px 

Earlier vs Now

![Screenshot 2024-08-21 at 8 55 38 PM](https://github.com/user-attachments/assets/fe2620ae-a9a2-4f4a-836d-11c3fc85bed5)
![Screenshot 2024-08-21 at 8 55 56 PM](https://github.com/user-attachments/assets/3e88239c-06e7-497a-8b61-633b06a9d315)

https://github.com/user-attachments/assets/2a49041b-1e60-429c-b1d2-fcef7596912c


## Type of change

<!-- Please delete options that are not relevant.-->

- [ ] Bug fix (non-breaking change which fixes an issue)
