### PR TITLE
 Enhance Header and ToggleSwitch Components to Close Navbar on Theme Toggle

### DIFF
--- a/src/components/ToggleSwitch/ToggleSwitch.js
+++ b/src/components/ToggleSwitch/ToggleSwitch.js
@@ -3,7 +3,7 @@ import emoji from "react-easy-emoji";
 import StyleContext from "../../contexts/StyleContext";
 import "./ToggleSwitch.scss";
 
-const ToggleSwitch = () => {
+const ToggleSwitch = ({handleMenuItemClick}) => {
   const {isDark} = useContext(StyleContext);
   const [isChecked, setChecked] = useState(isDark);
   const styleContext = useContext(StyleContext);
@@ -16,6 +16,7 @@ const ToggleSwitch = () => {
         onChange={() => {
           styleContext.changeTheme();
           setChecked(!isChecked);
+          handleMenuItemClick();
         }}
       />
       <span className="slider round">

--- a/src/components/header/Header.js
+++ b/src/components/header/Header.js
@@ -40,7 +40,12 @@ function Header() {
           <span className="logo-name">{greeting.username}</span>
           <span className="grey-color">/&gt;</span>
         </a>
-        <input className="menu-btn" type="checkbox" id="menu-btn" ref={menuCheckboxRef}/>
+        <input
+          className="menu-btn"
+          type="checkbox"
+          id="menu-btn"
+          ref={menuCheckboxRef}
+        />
         <label
           className="menu-icon"
           htmlFor="menu-btn"
@@ -90,7 +95,7 @@ function Header() {
           <li>
             {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
             <a>
-              <ToggleSwitch handleMenuItemClick={handleMenuItemClick}/>
+              <ToggleSwitch handleMenuItemClick={handleMenuItemClick} />
             </a>
           </li>
         </ul>

--- a/src/components/header/Header.js
+++ b/src/components/header/Header.js
@@ -1,4 +1,4 @@
-import React, {useContext} from "react";
+import React, {useContext, useRef} from "react";
 import Headroom from "react-headroom";
 import "./Header.scss";
 import ToggleSwitch from "../ToggleSwitch/ToggleSwitch";
@@ -24,6 +24,14 @@ function Header() {
   const viewTalks = talkSection.display;
   const viewResume = resumeSection.display;
 
+  const menuCheckboxRef = useRef(null);
+
+  const handleMenuItemClick = () => {
+    if (menuCheckboxRef.current) {
+      menuCheckboxRef.current.checked = false;
+    }
+  };
+
   return (
     <Headroom>
       <header className={isDark ? "dark-menu header" : "header"}>
@@ -32,7 +40,7 @@ function Header() {
           <span className="logo-name">{greeting.username}</span>
           <span className="grey-color">/&gt;</span>
         </a>
-        <input className="menu-btn" type="checkbox" id="menu-btn" />
+        <input className="menu-btn" type="checkbox" id="menu-btn" ref={menuCheckboxRef}/>
         <label
           className="menu-icon"
           htmlFor="menu-btn"
@@ -82,7 +90,7 @@ function Header() {
           <li>
             {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
             <a>
-              <ToggleSwitch />
+              <ToggleSwitch handleMenuItemClick={handleMenuItemClick}/>
             </a>
           </li>
         </ul>


### PR DESCRIPTION
Overview:
This update improves user experience by automatically closing the navigation menu when the theme is toggled in the header. This change ensures that users receive immediate feedback when switching between light and dark modes, maintaining a clean interface.

Changes Made:

1. Header Component:
   - Introduced a `useRef` hook to manage the state of the menu checkbox.
   - Added a `handleMenuItemClick` function to programmatically uncheck the menu when a menu item is clicked or the theme is toggled.
   - Passed `handleMenuItemClick` as a prop to the `ToggleSwitch` component for integration.

2. ToggleSwitch Component:
   - Updated to accept the `handleMenuItemClick` function as a prop.
   - Called `handleMenuItemClick` within the `onChange` event of the checkbox, ensuring the navbar closes when the theme is toggled.

Benefits:
- Improved user experience by ensuring that the navigation menu closes upon theme change, preventing any UI clutter.
- Maintained functionality and responsiveness of the header component.

Related Issues:
- resolves issue #735

Testing:
- Verified that toggling the theme properly closes the navbar.
- Ensured all existing functionalities of the header and toggle switch remain intact.