### PR TITLE
Fix: close nav menu when theme is toggled

### DIFF
--- a/src/components/ToggleSwitch/ToggleSwitch.js
+++ b/src/components/ToggleSwitch/ToggleSwitch.js
@@ -3,20 +3,23 @@ import emoji from "react-easy-emoji";
 import StyleContext from "../../contexts/StyleContext";
 import "./ToggleSwitch.scss";
 
-const ToggleSwitch = () => {
+const ToggleSwitch = ({closeMenu}) => {
   const {isDark} = useContext(StyleContext);
   const [isChecked, setChecked] = useState(isDark);
   const styleContext = useContext(StyleContext);
+
+  const handleToggle = () => {
+    styleContext.changeTheme();
+    setChecked(!isChecked);
+    closeMenu(); // Close the menu when the theme is toggled
+  };
 
   return (
     <label className="switch">
       <input
         type="checkbox"
         checked={isDark}
-        onChange={() => {
-          styleContext.changeTheme();
-          setChecked(!isChecked);
-        }}
+       onChange={handleToggle}
       />
       <span className="slider round">
         <span className="emoji">{isChecked ? emoji("🌜") : emoji("☀️")}</span>

--- a/src/components/ToggleSwitch/ToggleSwitch.js
+++ b/src/components/ToggleSwitch/ToggleSwitch.js
@@ -16,11 +16,7 @@ const ToggleSwitch = ({closeMenu}) => {
 
   return (
     <label className="switch">
-      <input
-        type="checkbox"
-        checked={isDark}
-       onChange={handleToggle}
-      />
+      <input type="checkbox" checked={isDark} onChange={handleToggle} />
       <span className="slider round">
         <span className="emoji">{isChecked ? emoji("🌜") : emoji("☀️")}</span>
       </span>

--- a/src/components/header/Header.js
+++ b/src/components/header/Header.js
@@ -1,4 +1,4 @@
-import React, {useContext} from "react";
+import React, {useContext, useRef} from "react";
 import Headroom from "react-headroom";
 import "./Header.scss";
 import ToggleSwitch from "../ToggleSwitch/ToggleSwitch";
@@ -24,6 +24,15 @@ function Header() {
   const viewTalks = talkSection.display;
   const viewResume = resumeSection.display;
 
+  const menuCheckboxRef = useRef(null);
+
+  //close the menu when theme is changes from mobile nav
+  const closeMenu = () => {
+    if (menuCheckboxRef.current) {
+      menuCheckboxRef.current.checked = false;
+    }
+  };
+
   return (
     <Headroom>
       <header className={isDark ? "dark-menu header" : "header"}>
@@ -32,7 +41,12 @@ function Header() {
           <span className="logo-name">{greeting.username}</span>
           <span className="grey-color">/&gt;</span>
         </a>
-        <input className="menu-btn" type="checkbox" id="menu-btn" />
+        <input
+          className="menu-btn"
+          type="checkbox"
+          id="menu-btn"
+          ref={menuCheckboxRef}
+        />
         <label
           className="menu-icon"
           htmlFor="menu-btn"
@@ -82,7 +96,7 @@ function Header() {
           <li>
             {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
             <a>
-              <ToggleSwitch />
+              <ToggleSwitch closeMenu={closeMenu}/>
             </a>
           </li>
         </ul>

--- a/src/components/header/Header.js
+++ b/src/components/header/Header.js
@@ -96,7 +96,7 @@ function Header() {
           <li>
             {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
             <a>
-              <ToggleSwitch closeMenu={closeMenu}/>
+              <ToggleSwitch closeMenu={closeMenu} />
             </a>
           </li>
         </ul>


### PR DESCRIPTION
# Description

This solved the issue #735. The issue was to enhance user experience by closing the mobile nav when switching between theme
Fixes #735

Changes:
I have used useRef hook to hook into menu icon and then use a function to set the value to unchecked of input (the menu icon is basically an input with type checked or unchecked). so when a user toggles the theme, this function is called that sets the input to unchecked, (making the menu close)


## Type of change

<!-- Please delete options that are not relevant.-->

- [ ] New feature (non-breaking change which adds functionality)

