### PR TITLE
Fix: Download Resume button now supports external download links and opens in new tab

### DIFF
--- a/src/containers/greeting/Greeting.js
+++ b/src/containers/greeting/Greeting.js
@@ -42,8 +42,10 @@ export default function Greeting() {
                 <Button text="Contact me" href="#contact" />
                 {greeting.resumeLink && (
                   <a
-                    href={require("./resume.pdf")}
-                    download="Resume.pdf"
+                    href={greeting.resumeLink}
+                    download
+                    target="_blank"
+                    rel="noopener noreferrer"
                     className="download-link-button"
                   >
                     <Button text="Download my resume" />


### PR DESCRIPTION
This pull request updates the download resume button logic to support external resume links such as Google Drive.

- Opens the resume in a new tab if the link is a shared view-only URL (e.g., Google Drive)
- Uses the `download` attribute when supported by the browser and the link allows direct download
- Fixes an issue where using `require("./resume.pdf")` caused errors with external URLs