### PR TITLE
Add GithubCalendar component with dark/light theme

### DIFF
--- a/src/components/GithubCalendar/GithubCalendar.js
+++ b/src/components/GithubCalendar/GithubCalendar.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import GitHubCalendar from 'react-github-calendar';
+import './GithubCalendar.scss';
+
+const GithubCalendar = ({ isDark }) => {
+  const purpleTheme = {
+    level0: "#2c2c3d",
+    level1: "#7737c4",
+    level2: "#6a1bb9",
+    level3: "#5a1aa3",
+    level4: "#55198b"
+  };
+
+  return (
+    <div
+      className={`github-activity-container ${
+        isDark ? "dark-github" : "light-github"
+      }`}
+    >
+      <h2 className="github-activity-heading" aria-label="GitHub Activity Section">GitHub Activity</h2>
+      <GitHubCalendar
+        username="your-github-username"
+        theme={purpleTheme}
+        blockSize={15}
+        blockMargin={5}
+        fontSize={16}
+      />
+    </div>
+  );
+};
+
+export default GithubCalendar;

--- a/src/components/GithubCalendar/GithubCalendar.js
+++ b/src/components/GithubCalendar/GithubCalendar.js
@@ -1,8 +1,8 @@
-import React from 'react';
-import GitHubCalendar from 'react-github-calendar';
-import './GithubCalendar.scss';
+import React from "react";
+import GitHubCalendar from "react-github-calendar";
+import "./GithubCalendar.scss";
 
-const GithubCalendar = ({ isDark }) => {
+const GithubCalendar = ({isDark}) => {
   const purpleTheme = {
     level0: "#2c2c3d",
     level1: "#7737c4",
@@ -17,7 +17,12 @@ const GithubCalendar = ({ isDark }) => {
         isDark ? "dark-github" : "light-github"
       }`}
     >
-      <h2 className="github-activity-heading" aria-label="GitHub Activity Section">GitHub Activity</h2>
+      <h2
+        className="github-activity-heading"
+        aria-label="GitHub Activity Section"
+      >
+        GitHub Activity
+      </h2>
       <GitHubCalendar
         username="your-github-username"
         theme={purpleTheme}

--- a/src/components/GithubCalendar/GithubCalendar.scss
+++ b/src/components/GithubCalendar/GithubCalendar.scss
@@ -1,0 +1,34 @@
+@import "../../_globalColor";
+
+.github-activity-container {
+  padding: 2rem;
+  margin: 2rem 1rem;
+  border-radius: 12px;
+  text-align: center;
+  box-shadow: 0 4px 12px $lightBoxShadowDark;
+  transition: background-color 0.3s ease, color 0.3s ease;
+
+  &.dark-github {
+    background-color: $darkBackground;
+    color: $textColorDark;
+
+    .github-activity-heading {
+      color: $buttonColor; // #55198b
+    }
+  }
+
+  &.light-github {
+    background-color: $lightBackground1;
+    color: $textColor;
+
+    .github-activity-heading {
+      color: $buttonColor; 
+    }
+  }
+}
+
+.github-activity-heading {
+  font-size: 2rem;
+  margin-bottom: 1.5rem;
+  font-weight: bold;
+}

--- a/src/components/GithubCalendar/GithubCalendar.scss
+++ b/src/components/GithubCalendar/GithubCalendar.scss
@@ -22,7 +22,7 @@
     color: $textColor;
 
     .github-activity-heading {
-      color: $buttonColor; 
+      color: $buttonColor;
     }
   }
 }


### PR DESCRIPTION
## Description

Added a new `GithubCalendar` component to display the GitHub contribution graph using the `react-github-calendar` library. The calendar is styled with a custom purple theme and fully supports both light and dark modes.

The component is reusable and takes an `isDark` prop to dynamically adjust the styling. It improves the portfolio’s ability to reflect open source engagement visually.

Fixes #793

---

## Motivation

As someone actively beginning my open source journey, I wanted a clean, visually appealing way to show GitHub contribution activity directly on the portfolio. This addition allows developers to reflect their consistency and OSS involvement — which is valuable for personal branding and resumes.

---

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

---

## Dependencies Added

- [`react-github-calendar`](https://www.npmjs.com/package/react-github-calendar)

---

## Usage

To use the component, import it and pass `isDark` as a prop:

```jsx
import GithubCalendar from "./components/GithubCalendar/GithubCalendar";

<GithubCalendar isDark={isDark} />
