### PR TITLE
Fix Icon Hover Color to Match Brand Colors (solve #802)

### DIFF
--- a/src/components/softwareSkills/SoftwareSkill.js
+++ b/src/components/softwareSkills/SoftwareSkill.js
@@ -1,21 +1,32 @@
-import React from "react";
+import React, { useState } from "react";
 import "./SoftwareSkill.scss";
-import {skillsSection} from "../../portfolio";
+import { skillsSection } from "../../portfolio";
 
 export default function SoftwareSkill() {
+  const [hoveredIndex, setHoveredIndex] = useState(null);
+
   return (
     <div>
       <div className="software-skills-main-div">
         <ul className="dev-icons">
-          {skillsSection.softwareSkills.map((skills, i) => {
+          {skillsSection.softwareSkills.map((skill, index) => {
+            const isHovered = hoveredIndex === index;
+
             return (
               <li
-                key={i}
+                key={index}
                 className="software-skill-inline"
-                name={skills.skillName}
+                name={skill.skillName}
+                onMouseEnter={() => setHoveredIndex(index)}
+                onMouseLeave={() => setHoveredIndex(null)}
               >
-                <i className={skills.fontAwesomeClassname}></i>
-                <p>{skills.skillName}</p>
+                <i
+                  className={skill.fontAwesomeClassname}
+                  style={{ color: isHovered ? skill.color : undefined }}
+                ></i>
+                <p style={{ color: isHovered ? skill.color : undefined }}>
+                  {skill.skillName}
+                </p>
               </li>
             );
           })}

--- a/src/components/softwareSkills/SoftwareSkill.js
+++ b/src/components/softwareSkills/SoftwareSkill.js
@@ -1,6 +1,6 @@
-import React, { useState } from "react";
+import React, {useState} from "react";
 import "./SoftwareSkill.scss";
-import { skillsSection } from "../../portfolio";
+import {skillsSection} from "../../portfolio";
 
 export default function SoftwareSkill() {
   const [hoveredIndex, setHoveredIndex] = useState(null);
@@ -22,9 +22,9 @@ export default function SoftwareSkill() {
               >
                 <i
                   className={skill.fontAwesomeClassname}
-                  style={{ color: isHovered ? skill.color : undefined }}
+                  style={{color: isHovered ? skill.color : undefined}}
                 ></i>
-                <p style={{ color: isHovered ? skill.color : undefined }}>
+                <p style={{color: isHovered ? skill.color : undefined}}>
                   {skill.skillName}
                 </p>
               </li>

--- a/src/portfolio.js
+++ b/src/portfolio.js
@@ -63,7 +63,7 @@ const skillsSection = {
   /* Make Sure to include correct Font Awesome Classname to view your icon
 https://fontawesome.com/icons?d=gallery */
 
-softwareSkills: [
+  softwareSkills: [
     {
       skillName: "html-5",
       fontAwesomeClassname: "fab fa-html5",
@@ -132,7 +132,6 @@ softwareSkills: [
   ],
   display: true // Set false to hide this section, defaults to true
 };
-
 
 // Education Section
 

--- a/src/portfolio.js
+++ b/src/portfolio.js
@@ -63,62 +63,76 @@ const skillsSection = {
   /* Make Sure to include correct Font Awesome Classname to view your icon
 https://fontawesome.com/icons?d=gallery */
 
-  softwareSkills: [
+softwareSkills: [
     {
       skillName: "html-5",
-      fontAwesomeClassname: "fab fa-html5"
+      fontAwesomeClassname: "fab fa-html5",
+      color: "#e34c26"
     },
     {
       skillName: "css3",
-      fontAwesomeClassname: "fab fa-css3-alt"
+      fontAwesomeClassname: "fab fa-css3-alt",
+      color: "#264de4"
     },
     {
       skillName: "sass",
-      fontAwesomeClassname: "fab fa-sass"
+      fontAwesomeClassname: "fab fa-sass",
+      color: "#cc6699"
     },
     {
       skillName: "JavaScript",
-      fontAwesomeClassname: "fab fa-js"
+      fontAwesomeClassname: "fab fa-js",
+      color: "#f7df1e"
     },
     {
       skillName: "reactjs",
-      fontAwesomeClassname: "fab fa-react"
+      fontAwesomeClassname: "fab fa-react",
+      color: "#61DBFB"
     },
     {
       skillName: "nodejs",
-      fontAwesomeClassname: "fab fa-node"
+      fontAwesomeClassname: "fab fa-node",
+      color: "#3c873a"
     },
     {
       skillName: "swift",
-      fontAwesomeClassname: "fab fa-swift"
+      fontAwesomeClassname: "fab fa-swift",
+      color: "#fa7343"
     },
     {
       skillName: "npm",
-      fontAwesomeClassname: "fab fa-npm"
+      fontAwesomeClassname: "fab fa-npm",
+      color: "#CB3837"
     },
     {
       skillName: "sql-database",
-      fontAwesomeClassname: "fas fa-database"
+      fontAwesomeClassname: "fas fa-database",
+      color: "#f29111"
     },
     {
       skillName: "aws",
-      fontAwesomeClassname: "fab fa-aws"
+      fontAwesomeClassname: "fab fa-aws",
+      color: "#FF9900"
     },
     {
       skillName: "firebase",
-      fontAwesomeClassname: "fas fa-fire"
+      fontAwesomeClassname: "fas fa-fire",
+      color: "#FFA611"
     },
     {
       skillName: "python",
-      fontAwesomeClassname: "fab fa-python"
+      fontAwesomeClassname: "fab fa-python",
+      color: "#3572A5"
     },
     {
       skillName: "docker",
-      fontAwesomeClassname: "fab fa-docker"
+      fontAwesomeClassname: "fab fa-docker",
+      color: "#0db7ed"
     }
   ],
   display: true // Set false to hide this section, defaults to true
 };
+
 
 // Education Section
 


### PR DESCRIPTION
# Description

This PR resolves issue #802, where the software skill icons displayed a default blue color on hover. The expected behavior is that each icon should show its brand-specific color when hovered.

Fixes #802 

Ensured the UI now reflects the appropriate hover color based on the icon's identity (e.g., Yellow for JS, etc.)

# Screenshots
![WhatsApp Image 2025-07-21 at 18 25 42_c20ee9f3](https://github.com/user-attachments/assets/07f32c7d-0b45-4071-9ab7-cdedfc409926)


![WhatsApp Image 2025-07-21 at 18 25 43_db8f38c4](https://github.com/user-attachments/assets/a148d80f-4536-486f-826a-e23bbd154ac0)

