### PR TITLE
Adjust the darkmode contrast with the animation

### DIFF
--- a/src/_globalColor.scss
+++ b/src/_globalColor.scss
@@ -36,7 +36,8 @@ $lightBackground2: rgb(255, 255, 255);
 $lightBackground3: #f5f2f4;
 $blogCardContainerColor: #586069;
 // dark background colors
-$darkBackground: #171c28;
+$darkBackground: #222831; // slightly lighter gray
+
 
 // light theme box shadows
 $lightBoxShadowDark: rgba(0, 0, 0, 0.2);

--- a/src/_globalColor.scss
+++ b/src/_globalColor.scss
@@ -38,7 +38,6 @@ $blogCardContainerColor: #586069;
 // dark background colors
 $darkBackground: #222831; // slightly lighter gray
 
-
 // light theme box shadows
 $lightBoxShadowDark: rgba(0, 0, 0, 0.2);
 $lightBoxShadow: rgba(0, 0, 0, 0.1);

--- a/src/containers/splashScreen/SplashScreen.css
+++ b/src/containers/splashScreen/SplashScreen.css
@@ -15,7 +15,7 @@
   text-decoration: none;
 }
 .splash-title {
-  background-color: ;
+  background-color:;
   font-family: "Agustina Regular", cursive;
   font-weight: bold;
   font-variant-ligatures: no-common-ligatures;

--- a/src/containers/splashScreen/SplashScreen.css
+++ b/src/containers/splashScreen/SplashScreen.css
@@ -15,6 +15,7 @@
   text-decoration: none;
 }
 .splash-title {
+  background-color: ;
   font-family: "Agustina Regular", cursive;
   font-weight: bold;
   font-variant-ligatures: no-common-ligatures;


### PR DESCRIPTION
### What this PR does
- Updates the dark mode background color to improve visibility of the homepage animation.
- Ensures the dark blue concentric circles and arrow remain distinguishable in dark mode.
- Improves overall visual hierarchy and design clarity.

### Why this matters
Previously, in dark mode, the circles and arrow in the homepage illustration blended into the background.  
This reduced the visual hierarchy and weakened the focal point of the design.  
With the updated background, these elements now stand out as intended.

### Screenshots
**Before
<img width="1800" height="817" alt="image" src="https://github.com/user-attachments/assets/bdeb3e13-5d47-4202-8b5c-0b8ea6a7ff51" />

 
**After 
<img width="1854" height="871" alt="image" src="https://github.com/user-attachments/assets/6521076b-88a9-4a88-82ea-78a33f96150c" />



### Related issue
Closes #816
